### PR TITLE
Changed 400 error code to 200 in the template

### DIFF
--- a/{{cookiecutter.project_slug}}/connect_processor/app/dynamic_validation.py
+++ b/{{cookiecutter.project_slug}}/connect_processor/app/dynamic_validation.py
@@ -62,6 +62,6 @@ def do_validate():
         response = json.dumps(json_data)
         return api.response_class(
             response=response,
-            status=400,
+            status=200,
             mimetype='application/json'
         )


### PR DESCRIPTION
If the dynamic validation replies with 400 error code, the following happens:

* Connect UI: validation just fails with a generic error
* CBC Sales wizard logs error 409 in console and continues the purchase process

If the validator replies with status=200 and speciifes the value_error – error is displayed in CBC and Connect as expected